### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY-mirror-api-logging:$IMAGE_TAG .
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/$ECR_REPOSITORY-mirror-api-logging:$IMAGE_TAG
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY-mirror-api-logging:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY-mirror-api-logging:$IMAGE_TAG" >> $GITHUB_OUTPUT
        
       - name: DockerHub login
         if: ${{ github.event.inputs.Environment == 'prod' }}
@@ -86,5 +86,5 @@ jobs:
           docker build -t $ECR_REGISTRY/mirror-api-logging:$IMAGE_TAG .
           echo "Pushing image to DockerHub..."
           docker push $ECR_REGISTRY/mirror-api-logging:$IMAGE_TAG
-          echo "::set-output name=image::$ECR_REGISTRY/mirror-api-logging:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/mirror-api-logging:$IMAGE_TAG" >> $GITHUB_OUTPUT
        


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


