### PR TITLE
add process restart

### DIFF
--- a/ebpf/main.go
+++ b/ebpf/main.go
@@ -237,6 +237,7 @@ func restartProcess() {
 
 	go func() {
 		for range ticker.C {
+			slog.Info("Restarting container")
 			os.Exit(3)
 		}
 	}()

--- a/ebpf/main.go
+++ b/ebpf/main.go
@@ -91,6 +91,8 @@ func run() {
 	}
 	source = string(byteString)
 
+	go restartProcess()
+
 	replaceBpfLogsMacros()
 	replaceMaxConnectionMapSize()
 	replaceArchType()
@@ -226,8 +228,18 @@ func run() {
 		slog.Info("Stopping pod watcher")
 		close(stopCh)
 	}
-	
+
 	slog.Info("signaled to terminate")
+}
+
+func restartProcess() {
+	ticker := time.NewTicker(10 * time.Minute)
+
+	go func() {
+		for range ticker.C {
+			os.Exit(3)
+		}
+	}()
 }
 
 func captureMemoryProfile() {


### PR DESCRIPTION
Why ?

- Most of the restarts of K8 pods were happening in 15-20 minutes, so we will restart internally around 10 minutes. 
- Looks like memory keeps growing internally somehow. 
- K8 pod restarts should not show up this way.