### PR TITLE
increase and  reset timer

### DIFF
--- a/ebpf/connections/factory.go
+++ b/ebpf/connections/factory.go
@@ -73,7 +73,7 @@ func convertToSingleByteArr(bufMap map[int][]byte) []byte {
 var (
 	disableEgress        = false
 	maxActiveConnections = 4096
-	inactivityThreshold  = 3 * time.Second
+	inactivityThreshold  = 7 * time.Second
 	// Value in MB
 	bufferMemThreshold = 400
 
@@ -201,6 +201,25 @@ func (factory *Factory) CreateIfNotExists(connectionID structs.ConnID) {
 	}
 }
 
+// resetTimer stops, drains, and resets the timer to the given duration.
+func resetTimer(t *time.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(d)
+}
+
+// Worker lifecycle:
+//   ACTIVE:
+//     - socket data/open -> reset inactivity timer on each event
+//     - socket close     -> schedule delayed termination
+//     - inactivity timer -> terminate immediately
+//
+//   TERMINATION is final and happens exactly once.
+//  either due to inactivityThreshold or due to socker close event
 func (factory *Factory) StartWorker(connectionID structs.ConnID, tracker *Tracker, ch chan interface{}) {
 	go func(connID structs.ConnID, tracker *Tracker, ch chan interface{}) {
 
@@ -216,9 +235,11 @@ func (factory *Factory) StartWorker(connectionID structs.ConnID, tracker *Tracke
 				case *structs.SocketDataEvent:
 					utils.LogProcessing("Received data event", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 					tracker.AddDataEvent(*e)
+					resetTimer(inactivityTimer, inactivityThreshold)
 				case *structs.SocketOpenEvent:
 					utils.LogProcessing("Received open event", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 					tracker.AddOpenEvent(*e)
+					resetTimer(inactivityTimer, inactivityThreshold)
 				case *structs.SocketCloseEvent:
 					utils.LogProcessing("Received close event", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 					tracker.AddCloseEvent(*e)

--- a/ebpf/connections/factory.go
+++ b/ebpf/connections/factory.go
@@ -80,6 +80,8 @@ var (
 	// unique id of daemonset
 	uniqueDaemonsetId          = uuid.New().String()
 	trackerDataProcessInterval = 100
+
+	socketDataEventBytesThreshold = 10 * 1024 * 1024
 )
 
 func init() {
@@ -89,6 +91,7 @@ func init() {
 	utils.InitVar("TRAFFIC_BUFFER_THRESHOLD", &bufferMemThreshold)
 	utils.InitVar("AKTO_MEM_SOFT_LIMIT", &bufferMemThreshold)
 	utils.InitVar("TRACKER_DATA_PROCESS_INTERVAL", &trackerDataProcessInterval)
+	utils.InitVar("SOCKET_DATA_EVENT_BYTES_THRESHOLD", &socketDataEventBytesThreshold)
 }
 
 func ProcessTrackerData(connID structs.ConnID, tracker *Tracker, isComplete bool) {
@@ -235,7 +238,13 @@ func (factory *Factory) StartWorker(connectionID structs.ConnID, tracker *Tracke
 				case *structs.SocketDataEvent:
 					utils.LogProcessing("Received data event", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 					tracker.AddDataEvent(*e)
-					resetTimer(inactivityTimer, inactivityThreshold)
+					if tracker.GetSentBytes() + tracker.GetRecvBytes() > uint64(socketDataEventBytesThreshold) {
+						utils.LogProcessing("Socket Data threshold data breached, processing current data", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
+						factory.StopProcessing(connID)
+						return
+					}else{
+						resetTimer(inactivityTimer, inactivityThreshold)
+					}
 				case *structs.SocketOpenEvent:
 					utils.LogProcessing("Received open event", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 					tracker.AddOpenEvent(*e)
@@ -251,20 +260,23 @@ func (factory *Factory) StartWorker(connectionID structs.ConnID, tracker *Tracke
 
 			case <-delayedDeleteChan:
 				utils.LogProcessing("Stopping go routine (delayed close)", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
-				factory.ProcessAndStopWorker(connID)
-				factory.DeleteWorker(connID)
+				factory.StopProcessing(connID)
 				return
 
 			case <-inactivityTimer.C:
 				// Eat the go routine after inactive threshold, process the tracker and stop the worker
 				utils.LogProcessing("Inactivity threshold reached, marking connection as inactive and processing", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
-				factory.ProcessAndStopWorker(connID)
-				factory.DeleteWorker(connID)
+				factory.StopProcessing(connID)
 				utils.LogProcessing("Stopping go routine", "fd", connID.Fd, "id", connID.Id, "timestamp", connID.Conn_start_ns, "ip", connID.Ip, "port", connID.Port)
 				return
 			}
 		}
 	}(connectionID, tracker, ch)
+}
+
+func (factory *Factory) StopProcessing(connID structs.ConnID){
+	factory.ProcessAndStopWorker(connID)
+	factory.DeleteWorker(connID)
 }
 
 func (factory *Factory) ProcessAndStopWorker(connectionID structs.ConnID) {

--- a/ebpf/connections/tracker.go
+++ b/ebpf/connections/tracker.go
@@ -108,3 +108,11 @@ func (conn *Tracker) AddCloseEvent(event structs.SocketCloseEvent) {
 	conn.closeTimestamp = uint64(time.Now().UnixNano())
 	conn.lastAccessTimestamp = uint64(time.Now().UnixNano())
 }
+
+func (conn *Tracker) GetSentBytes() uint64 {
+	return conn.sentBytes
+}
+
+func (conn *Tracker) GetRecvBytes() uint64 {
+	return conn.recvBytes
+}


### PR DESCRIPTION
### Why ?

We observed requests with response time > 3sec were not being captured in our module.

Here are other cases of missed requests.


Scenario | Why It's Missed
-- | --
Slow responses (>3s) | If a server takes longer than 3 seconds to respond, the worker terminates before capturing the response
Large file uploads/downloads | Data transfer exceeding 3 seconds gets cut off mid-stream
HTTP keep-alive connections | Multiple requests on the same connection — only the first ~3 seconds of traffic is captured
WebSocket/long-polling | Any persistent connection is terminated after 3 seconds
Slow clients | Clients sending data slowly (e.g., mobile on poor network)



### Solution
- Reset the timer on each event received. This solves the multiple data events received case
- Needs verification: What exactly happens in keep-alive case. Do we get multiple open for multiple requests ??
- If close is not received in 7sec then we terminate.


### Learnings
- https://pkg.go.dev/time#NewTimer
- https://pkg.go.dev/time#Timer.Reset
- https://antonz.org/timer-reset/#123-fix
- https://dev.to/milktea02/misunderstanding-go-timers-and-channels-1jal
