### PR TITLE
[DO NOT MERGE] Feature/ebpf 611 headers

### DIFF
--- a/Dockerfile.eBPF
+++ b/Dockerfile.eBPF
@@ -2,6 +2,11 @@ FROM alpine:3.22 AS base
 
 USER root
 RUN apk add bcc-tools bcc-dev bcc-doc linux-headers build-base
+# Patch kernel headers for BPF_LOAD_ACQ/BPF_STORE_REL when missing (e.g. on AWS Graviton arm64 / kernel 6.17.0-1007-aws)
+RUN grep -q "BPF_LOAD_ACQ" /usr/include/linux/bpf.h 2>/dev/null || ( \
+	echo "#ifndef BPF_LOAD_ACQ"; echo "#define BPF_LOAD_ACQ 0x100"; echo "#endif"; \
+	echo "#ifndef BPF_STORE_REL"; echo "#define BPF_STORE_REL 0x110"; echo "#endif"; \
+	cat /usr/include/linux/bpf.h ) > /tmp/bpf.h && mv /tmp/bpf.h /usr/include/linux/bpf.h
 
 FROM base AS builder
 

--- a/Dockerfile.eBPF
+++ b/Dockerfile.eBPF
@@ -44,6 +44,7 @@ FROM base
 WORKDIR /ebpf
 COPY --from=builder /ebpf/ebpf-logging /ebpf/ebpf-logging
 COPY --from=builder /ebpf/kernel/module.cc /ebpf/kernel/module.cc
+COPY --from=builder /ebpf/kernel/bpf_compat.h /ebpf/kernel/bpf_compat.h
 COPY ebpf-run.sh /ebpf/ebpf-run.sh
 RUN chmod +x /ebpf/ebpf-run.sh
 

--- a/ebpf/kernel/bpf_compat.h
+++ b/ebpf/kernel/bpf_compat.h
@@ -1,0 +1,12 @@
+/*
+ * Compatibility defines for BPF atomic opcodes (kernel March 2025).
+ * Force-included so they are defined before host kernel headers (e.g. from
+ * -v /usr/src:/usr/src) that reference BPF_LOAD_ACQ/BPF_STORE_REL but may
+ * not define them (e.g. AWS Graviton kernel 6.17.0-1007-aws).
+ */
+#ifndef BPF_LOAD_ACQ
+#define BPF_LOAD_ACQ  0x100
+#endif
+#ifndef BPF_STORE_REL
+#define BPF_STORE_REL 0x110
+#endif

--- a/ebpf/main.go
+++ b/ebpf/main.go
@@ -105,7 +105,10 @@ func run() {
 
 	bpfwrapper.DeleteExistingAktoKernelProbes()
 
-	bpfModule := bcc.NewModule(source, []string{})
+	// Force-include compat header so BPF_LOAD_ACQ/BPF_STORE_REL are defined before host
+	// headers (from -v /usr/src:/usr/src) are included. Does not modify host.
+	cflags := []string{"-include", "kernel/bpf_compat.h"}
+	bpfModule := bcc.NewModule(source, cflags)
 	if bpfModule == nil {
 		slog.Error("failed to create BPF module", "error", "module is nil")
 		panic("bpf module is nil")


### PR DESCRIPTION
for ref. , this bypasses the limitations cased by https://github.com/amazonlinux/amazon-linux-2023/issues/1011 , in Ubuntu 24.04 AMIs

should not be needed once upstream is fixed.

the image is `aktosecurity/mirror-api-logging:k8s_ebpf_new_kernel_2` if needed