### PR TITLE
Use source IP as Kafka partition key for akto.api.logs

### DIFF
--- a/trafficUtil/kafkaUtil/kafka.go
+++ b/trafficUtil/kafkaUtil/kafka.go
@@ -110,7 +110,7 @@ func InitKafka() {
 
 		out, _ := json.Marshal(value)
 		ctx := context.Background()
-		err := ProduceStr(ctx, string(out), "testKafkaConnection", "testKafkaConnectionHost", "")
+		err := ProduceStr(ctx, string(out), "testKafkaConnection", "testKafkaConnectionHost", "", "")
 		utils.PrintLog("logging kafka stats post pushing message")
 		LogKafkaStats()
 		if err != nil {
@@ -435,12 +435,13 @@ func buildCollectionDetailsHeader(host, method, url string) []kafka.Header {
 	}
 }
 
-func ProduceStr(ctx context.Context, message string, url, reqHost, method string) error {
+func ProduceStr(ctx context.Context, message string, url, reqHost, method, ip string) error {
 	topic := "akto.api.logs"
 	checkDebugUrlAndPrint(url, reqHost, "begin kafka write to akto.api.logs topic")
 
 	msg := kafka.Message{
 		Topic:   topic,
+		Key:     []byte(ip),
 		Value:   []byte(message),
 		Headers: buildCollectionDetailsHeader(reqHost, method, url),
 	}

--- a/trafficUtil/kafkaUtil/parser.go
+++ b/trafficUtil/kafkaUtil/parser.go
@@ -719,7 +719,7 @@ func ParseAndProduce(receiveBuffer []byte, sentBuffer []byte, ctx TrafficContext
 
 		} else {
 			// Produce to kafka with collection_details header
-			go ProduceStr(bgCtx, string(out), url, req.Host, req.Method)
+			go ProduceStr(bgCtx, string(out), url, req.Host, req.Method, ip)
 
 			// Only if threat enabled
 			if utils.ThreatEnabled {


### PR DESCRIPTION
## Summary

- Added `ip string` parameter to `ProduceStr` and set it as `kafka.Message.Key`
- Updated call site in `ParseAndProduce` to pass the resolved source IP
- Fixed the test connection call in `kafka.go` to pass an empty string (no IP context there)

The writer already uses `&kafka.Hash{}` balancer, so messages with the same source IP will now consistently route to the same partition — matching the existing behaviour of the `Produce` function (`akto.api.logs2` topic).

## Test plan

- [ ] Verify traffic from the same source IP lands on the same Kafka partition
- [ ] Verify the test Kafka connection flow still works (empty key → hash balancer distributes freely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)