### PR TITLE
Read/update env value from UI

### DIFF
--- a/config_consumer.go
+++ b/config_consumer.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl/plain"
+)
+
+type MessageType string
+
+const (
+	MessageTypeEnvReload MessageType = "ENV_RELOAD"
+	MessageTypeRestart   MessageType = "RESTART"
+)
+
+// envFilePath is where the current environment is persisted so run.sh can
+// source it and the freshly-restarted process inherits the updated vars.
+// Keep this in sync with run.sh.
+func envFilePath() string {
+	if p := os.Getenv("AKTO_ENV_FILE"); p != "" {
+		return p
+	}
+	return "/app/.env"
+}
+
+// TrafficAgentCommandMessage mirrors the akto.config.updates command payload.
+// filter_header has no daemon/pod identity, so only the flat Env map is used;
+// DaemonNames / DaemonEnvMap are accepted for wire-compatibility but ignored.
+type TrafficAgentCommandMessage struct {
+	MessageType  MessageType                  `json:"messageType"`
+	DaemonNames  []string                     `json:"daemonNames"`
+	Env          map[string]string            `json:"env"`
+	DaemonEnvMap map[string]map[string]string `json:"daemonEnvMap"`
+	Timestamp    int64                        `json:"timestamp"`
+}
+
+// writeEnvFile serializes the current process environment into a shell-sourceable
+// file, written atomically so run.sh never sees a partial file.
+func writeEnvFile() error {
+	finalPath := envFilePath()
+	tmpPath := finalPath + ".tmp"
+
+	var content strings.Builder
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := parts[0]
+		val := parts[1]
+
+		content.WriteString("export ")
+		content.WriteString(key)
+		content.WriteString("=")
+		content.WriteString(strconv.Quote(val)) // shell-safe escaping
+		content.WriteString("\n")
+	}
+
+	if err := os.WriteFile(tmpPath, []byte(content.String()), 0644); err != nil {
+		slog.Error("Failed to write environment file", "path", tmpPath, "error", err)
+		return err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		slog.Error("Failed to rename environment file", "path", tmpPath, "error", err)
+		return err
+	}
+	slog.Debug("Environment variables written to file", "path", finalPath)
+	return nil
+}
+
+// restartSelf persists the current environment then exits, letting run.sh's
+// supervising loop spawn a fresh process that sources the updated env.
+func restartSelf() {
+	slog.Warn("Restarting process with new environment...")
+	if err := writeEnvFile(); err != nil {
+		slog.Error("Failed to persist environment before restart", "error", err)
+	}
+	os.Exit(0)
+}
+
+// processCommandMessage handles a single command message.
+func processCommandMessage(command TrafficAgentCommandMessage) {
+	switch command.MessageType {
+	case MessageTypeRestart:
+		slog.Info("Received RESTART command, restarting process...")
+		restartSelf()
+
+	case MessageTypeEnvReload:
+		if len(command.Env) == 0 {
+			slog.Warn("ENV_RELOAD with no environment variables provided, ignoring")
+			return
+		}
+
+		slog.Info("Processing ENV_RELOAD command", "envCount", len(command.Env))
+
+		changed := false
+		for key, value := range command.Env {
+			oldValue := os.Getenv(key)
+			if oldValue != value {
+				slog.Warn("Updating environment variable", "key", key, "oldValue", oldValue, "newValue", value)
+				os.Setenv(key, value)
+				changed = true
+			}
+		}
+
+		if !changed {
+			slog.Info("ENV_RELOAD produced no changes, skipping restart")
+			return
+		}
+
+		slog.Info("Environment variables updated, restarting process...")
+		restartSelf()
+
+	default:
+		slog.Warn("Unknown message type, ignoring", "messageType", command.MessageType)
+	}
+}
+
+// getConfigKafkaDialer builds a dialer with the same TLS/SASL settings used by
+// the rest of the Kafka clients in this agent.
+func getConfigKafkaDialer() *kafka.Dialer {
+	dialer := &kafka.Dialer{}
+	if useTLS {
+		if tlsConfig, err := NewTLSConfig(tlsCACertPath); err == nil {
+			dialer.TLS = tlsConfig
+		} else {
+			slog.Error("Failed to build TLS config for config consumer", "error", err)
+		}
+	}
+	if isAuthImplemented && kafkaUsername != "" && kafkaPassword != "" {
+		dialer.SASLMechanism = plain.Mechanism{Username: kafkaUsername, Password: kafkaPassword}
+	}
+	return dialer
+}
+
+// StartConfigConsumer subscribes to akto.config.updates and applies ENV_RELOAD /
+// RESTART commands. Each process uses a unique consumer group so every agent
+// receives every command (broadcast semantics).
+func StartConfigConsumer() {
+	kafkaURL := getKafkaUrl()
+	if kafkaURL == "" {
+		slog.Warn("Kafka URL not configured, config consumer disabled")
+		return
+	}
+
+	topic := "akto.config.updates"
+	// Unique per process so commands are not load-balanced away from any agent.
+	hostname, _ := os.Hostname()
+	groupID := fmt.Sprintf("mirroring-config-consumer-%s-%s", collectorId, hostname)
+
+	slog.Info("Starting config consumer", "topic", topic, "groupID", groupID)
+
+	readerConfig := kafka.ReaderConfig{
+		Brokers:        []string{kafkaURL},
+		Topic:          topic,
+		GroupID:        groupID,
+		MinBytes:       1,
+		MaxBytes:       10e6,
+		CommitInterval: time.Second,
+		StartOffset:    kafka.LastOffset,
+		Dialer:         getConfigKafkaDialer(),
+	}
+
+	reader := kafka.NewReader(readerConfig)
+
+	go func() {
+		defer reader.Close()
+
+		ctx := context.Background()
+		for {
+			msg, err := reader.FetchMessage(ctx)
+			if err != nil {
+				slog.Error("Error reading config update message", "error", err)
+				time.Sleep(time.Second)
+				continue
+			}
+
+			slog.Debug("Received command message", "value", string(msg.Value))
+
+			var command TrafficAgentCommandMessage
+			if err := json.Unmarshal(msg.Value, &command); err != nil {
+				slog.Error("Failed to parse command message", "error", err)
+				if err := reader.CommitMessages(ctx, msg); err != nil {
+					slog.Error("Failed to commit unparseable message", "error", err)
+				}
+				continue
+			}
+
+			if err := reader.CommitMessages(ctx, msg); err != nil {
+				slog.Error("Failed to commit message offset", "error", err)
+			}
+
+			processCommandMessage(command)
+		}
+	}()
+
+	slog.Info("Config consumer started successfully")
+}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/akto-api-security/mirroring-api-logging/utils"
+	"github.com/google/uuid"
+	"github.com/segmentio/kafka-go"
+)
+
+const moduleType = "TRAFFIC_COLLECTOR"
+
+var (
+	heartbeatIntervalSeconds = 60
+	uniqueDaemonsetId        = uuid.New().String()
+
+	lastCPUTime     float64
+	lastMeasureTime time.Time
+	cpuMutex        sync.Mutex
+)
+
+func init() {
+	utils.InitVar("KAFKA_HEARTBEAT_INTERVAL_SECONDS", &heartbeatIntervalSeconds)
+}
+
+func getEnvData() map[string]string {
+	envMap := make(map[string]string)
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+	return envMap
+}
+
+func getCPUUsage() (cpuPercent float64, cpuCoresUsed float64) {
+	var rusage syscall.Rusage
+	syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
+
+	totalCPUSec := float64(rusage.Utime.Sec+rusage.Stime.Sec) +
+		float64(rusage.Utime.Usec+rusage.Stime.Usec)/1000000
+
+	cpuMutex.Lock()
+	defer cpuMutex.Unlock()
+
+	now := time.Now()
+	if !lastMeasureTime.IsZero() {
+		elapsed := now.Sub(lastMeasureTime).Seconds()
+		cpuDelta := totalCPUSec - lastCPUTime
+		cpuPercent = (cpuDelta / elapsed) * 100
+		cpuCoresUsed = cpuDelta / elapsed
+	}
+
+	lastCPUTime = totalCPUSec
+	lastMeasureTime = now
+
+	return cpuPercent, cpuCoresUsed
+}
+
+func getProfilingData() map[string]interface{} {
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	cpuPercent, cpuCoresUsed := getCPUUsage()
+
+	return map[string]interface{}{
+		"memory_used_mb":       float64(memStats.Alloc) / 1024 / 1024,
+		"memory_total_mb":      float64(memStats.Sys) / 1024 / 1024,
+		"memory_cumulative_mb": float64(memStats.TotalAlloc) / 1024 / 1024,
+		"cpu_percent":          cpuPercent,
+		"cpu_cores_used":       cpuCoresUsed,
+		"cpu_cores_total":      runtime.NumCPU(),
+		"goroutines":           runtime.NumGoroutine(),
+		"num_gc":               memStats.NumGC,
+	}
+}
+
+// getDaemonPodName derives a stable-ish identity for this agent instance.
+func getDaemonPodName() string {
+	if aktoAgentName := os.Getenv("AKTO_AGENT_NAME"); aktoAgentName != "" {
+		return fmt.Sprintf("akto-tc:%s", aktoAgentName)
+	}
+	podName := os.Getenv("POD_NAME")
+	nodeName := os.Getenv("NODE_NAME")
+	if podName != "" && nodeName != "" {
+		return fmt.Sprintf("akto-tc:%s:%s", podName, nodeName)
+	}
+	hostname := os.Getenv("HOSTNAME")
+	if hostname == "" {
+		hostname = fmt.Sprintf("daemon-%s", uniqueDaemonsetId[:8])
+	}
+	return fmt.Sprintf("akto-tc:%s", hostname)
+}
+
+func getImageVersion() string {
+	imageVersion := os.Getenv("AKTO_IMAGE_VERSION")
+	if imageVersion == "" {
+		imageVersion = "aktosecurity/mirror-api-logging:filter-header"
+	}
+	return imageVersion
+}
+
+// ProduceHeartbeat writes a heartbeat to the heartbeat topic using the shared writer.
+func ProduceHeartbeat(ctx context.Context, heartbeatData map[string]string) error {
+	writer := kafkaWriter
+	if writer == nil {
+		slog.Warn("Kafka writer not ready, skipping heartbeat")
+		return nil
+	}
+
+	out, err := json.Marshal(heartbeatData)
+	if err != nil {
+		return err
+	}
+
+	topic := "akto.daemonset.producer.heartbeats"
+	msg := kafka.Message{
+		Topic: topic,
+		Value: out,
+	}
+
+	if err := writer.WriteMessages(ctx, msg); err != nil {
+		slog.Error("ERROR while writing heartbeat messages", "topic", topic, "error", err)
+		return err
+	}
+	return nil
+}
+
+func sendHeartbeatMessage(ctx context.Context, daemonPodName, imageVersion string) {
+	additionalData := map[string]interface{}{
+		"env":       getEnvData(),
+		"profiling": getProfilingData(),
+	}
+
+	additionalDataJSON, err := json.Marshal(additionalData)
+	if err != nil {
+		slog.Error("Failed to marshal additionalData", "error", err)
+		additionalDataJSON = []byte("{}")
+	}
+
+	heartbeatMessage := map[string]string{
+		"type":           "heartbeat",
+		"daemonId":       uniqueDaemonsetId,
+		"daemonPodName":  daemonPodName,
+		"timestamp":      fmt.Sprint(time.Now().Unix()),
+		"moduleType":     moduleType,
+		"imageVersion":   imageVersion,
+		"additionalData": string(additionalDataJSON),
+	}
+
+	slog.Debug("Sending Kafka heartbeat", "daemonPod", daemonPodName, "imageVersion", imageVersion)
+	if err := ProduceHeartbeat(ctx, heartbeatMessage); err != nil {
+		slog.Error("Failed to send heartbeat to Kafka", "error", err)
+	}
+}
+
+// sendKafkaHeartbeat periodically ships env + profiling data as a heartbeat.
+// Runs forever; intended to be launched as a goroutine.
+func sendKafkaHeartbeat() {
+	if heartbeatIntervalSeconds <= 0 {
+		slog.Info("Kafka heartbeat disabled", "interval", heartbeatIntervalSeconds)
+		return
+	}
+
+	daemonPodName := getDaemonPodName()
+	imageVersion := getImageVersion()
+	ctx := context.Background()
+
+	slog.Info("Starting Kafka heartbeat routine", "interval_seconds", heartbeatIntervalSeconds, "daemonPod", daemonPodName, "daemonId", uniqueDaemonsetId)
+	sendHeartbeatMessage(ctx, daemonPodName, imageVersion)
+
+	for {
+		jitter := time.Duration(1+rand.Intn(5)) * time.Second
+		sleepDuration := time.Duration(heartbeatIntervalSeconds)*time.Second + jitter
+		time.Sleep(sleepDuration)
+		sendHeartbeatMessage(ctx, daemonPodName, imageVersion)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1123,6 +1123,10 @@ func main() {
 		interfaceName = "any"
 	}
 	initKafka()
+
+	// Listen for ENV_RELOAD / RESTART commands on akto.config.updates.
+	StartConfigConsumer()
+
 	for {
 		if handle, err := pcap.OpenLive(interfaceName, 128*1024, true, pcap.BlockForever); err != nil {
 			log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1127,6 +1127,9 @@ func main() {
 	// Listen for ENV_RELOAD / RESTART commands on akto.config.updates.
 	StartConfigConsumer()
 
+	// Periodically publish env + profiling heartbeats.
+	go sendKafkaHeartbeat()
+
 	for {
 		if handle, err := pcap.OpenLive(interfaceName, 128*1024, true, pcap.BlockForever); err != nil {
 			log.Fatal(err)

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 LOG_FILE="/tmp/dump.log"
 MAX_LOG_SIZE=${MAX_LOG_SIZE:-10485760}  # Default to 10 MB (10 * 1024 * 1024 bytes)
 CHECK_INTERVAL=60                        # Check interval in seconds
+ENV_FILE="${AKTO_ENV_FILE:-/app/.env}"   # Env persisted by ENV_RELOAD; keep in sync with config_consumer.go
 
 # Function to rotate the log file
 rotate_log() {
@@ -24,6 +25,14 @@ fi
 
 while :
 do
+    # Load env updates persisted by the previous process before (re)starting,
+    # so ENV_RELOAD changes survive the os.Exit-based restart.
+    if [ -f "$ENV_FILE" ]; then
+        set -a
+        . "$ENV_FILE"
+        set +a
+    fi
+
     # Start the mirroring module in the background
     if [[ "${ENABLE_LOGS}" == "false" ]]; then
         /mirroring-api-logging >> "$LOG_FILE" 2>&1 &


### PR DESCRIPTION
Lets the backend push env changes to the mirroring agent over Kafka. On `ENV_RELOAD` the agent updates its env, persists it, and restarts so the new values take effect; the persisted env survives the restart.

## Flow

```mermaid
sequenceDiagram
    participant BE as Backend (UI)
    participant K as Kafka<br/>akto.config.updates
    participant C as StartConfigConsumer
    participant F as /app/.env
    participant S as run.sh loop
    participant P as new process

    BE->>K: {messageType: ENV_RELOAD, env:{...}}
    K->>C: FetchMessage
    C->>C: os.Setenv(changed keys)
    alt something changed
        C->>F: writeEnvFile() (atomic)
        C->>C: os.Exit(0)
        S->>F: source /app/.env (set -a)
        S->>P: start /mirroring-api-logging
        Note over P: runs with updated env
    else no change
        C-->>C: skip restart
    end
```

## Changes
- **config_consumer.go** — Kafka consumer on `akto.config.updates`. Unique consumer group per process (broadcast: every agent gets every command). `ENV_RELOAD` applies flat `env` map + restarts on change; `RESTART` restarts. Reuses branch TLS/SASL config.
- **main.go** — `StartConfigConsumer()` started after `initKafka()`.
- **run.sh** — sources `${AKTO_ENV_FILE:-/app/.env}` before each launch so env changes survive the `os.Exit(0)` restart.

## Notes
- Env file path configurable via `AKTO_ENV_FILE` (default `/app/.env`); needs a writable path if rootfs is read-only.
- Assumes backend broadcasts to the topic (each agent has its own consumer group).
